### PR TITLE
Handle `no ci` label to prevent bogus auto-merges

### DIFF
--- a/.github/workflows/conform-pr.yml
+++ b/.github/workflows/conform-pr.yml
@@ -44,7 +44,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     # No `trust` label check because we don't checkout PR's code.
-    if: github.event_name != 'pull_request_target' || !contains(github.event.pull_request.labels.*.name, 'no ci')
+    # No `no ci` label to prevent accidental auto-merges: jobs skipped with `if` conditional are considered successful.
+    if: github.event_name != 'pull_request_target'
 
     steps:
       # Warning! Be careful about changing the steps here as it might cause some security problems

--- a/conform-pr/main.go
+++ b/conform-pr/main.go
@@ -167,10 +167,6 @@ func (c *checker) runChecks(ctx context.Context, org, user, nodeID string) ([]ch
 
 // checkLabels checks if PR's labels are valid.
 func checkLabels(action *githubactions.Action, labels []string) error {
-	if slices.Contains(labels, "no ci") {
-		action.Fatalf(`"no ci" label should be handled by configuration, not conform-pr`)
-	}
-
 	var res []string
 
 	for _, l := range []string{
@@ -195,6 +191,10 @@ func checkLabels(action *githubactions.Action, labels []string) error {
 
 	if slices.Contains(labels, "do not merge") {
 		return fmt.Errorf("That PR should not be merged yet.")
+	}
+
+	if slices.Contains(labels, "no ci") {
+		return fmt.Errorf("That PR can't be merged yet; remove `no ci` label.")
 	}
 
 	return nil


### PR DESCRIPTION
<img width="512" alt="CleanShot 2022-11-29 at 17 19 39@2x" src="https://user-images.githubusercontent.com/11512/204539649-d1bca161-3d7a-4bdc-a801-41997c1a4af7.png">

See FerretDB/FerretDB#1580. Here, I added and removed `no ci` label to trigger rebuild, but PR was merged immediately.