### PR TITLE
Do less API calls in `conform-pr`

### DIFF
--- a/.github/workflows/conform-pr.yml
+++ b/.github/workflows/conform-pr.yml
@@ -48,7 +48,7 @@ on:
 
 # Do not run this workflow in parallel for any PR change.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
 
 env:
   GOPATH: /home/runner/go

--- a/.github/workflows/conform-pr.yml
+++ b/.github/workflows/conform-pr.yml
@@ -12,7 +12,7 @@
 #   Only a few trusted people have permission to do that.
 # * Thanks to the way `pull_request_target` trigger works,
 #   PR changes in the workflow itself are not run until they are merged.
-# * We use a short-lived automatic `GITHUB_TOKEN` instead of a long-living personal access token (PAT) where possible.
+# * We use short-lived automatic `GITHUB_TOKEN`s instead of a long-living personal access tokens (PAT) where possible.
 # * Both `GITHUB_TOKEN`s and PATs have minimal permissions.
 # * We publish Docker images from PRs as a separate packages that should not be run by users.
 # * We limit what third-party actions can be used.
@@ -57,7 +57,6 @@ env:
   GOMODCACHE: /home/runner/go/mod
   GOPROXY: https://proxy.golang.org
   GOTOOLCHAIN: local
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CONFORM_TOKEN: ${{ secrets.CONFORM_TOKEN }} # repo-scoped GITHUB_TOKEN is not enough to query org-level projects
 
 jobs:

--- a/conform-pr/main.go
+++ b/conform-pr/main.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v56/github"
 	"github.com/jdkato/prose/v2"
 	"github.com/sethvargo/go-githubactions"
 	"golang.org/x/exp/maps"

--- a/conform-pr/main_test.go
+++ b/conform-pr/main_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sethvargo/go-githubactions"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/FerretDB/github-actions/internal"
 	"github.com/FerretDB/github-actions/internal/graphql"
 )
 
@@ -34,7 +33,6 @@ func TestRunPRChecks(t *testing.T) {
 	action := githubactions.New()
 	c := &checker{
 		action:  action,
-		client:  internal.GitHubClient(ctx, action, "GITHUB_TOKEN"),
 		gClient: graphql.NewClient(ctx, action, "CONFORM_TOKEN"),
 	}
 

--- a/conform-pr/main_test.go
+++ b/conform-pr/main_test.go
@@ -47,9 +47,9 @@ func TestRunPRChecks(t *testing.T) {
 		expectedCommunity bool
 	}{{
 		name:              "Dependabot",
-		user:              "dependabot",
+		user:              "dependabot[bot]",
 		nodeID:            "PR_kwDOGfwnTc48nVkp", // https://github.com/FerretDB/github-actions/pull/83
-		expectedCommunity: true,
+		expectedCommunity: false,
 	}, {
 		name:   "OneProjectAllFieldsUnset",
 		user:   "AlekSi",

--- a/conform-pr/team.go
+++ b/conform-pr/team.go
@@ -1,0 +1,27 @@
+// Copyright 2021 FerretDB Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// FerretDB organization members.
+var maintainers = map[string]struct{}{
+	"ferretdb-bot": {},
+	"ptrfarkas":    {},
+	"AlekSi":       {},
+	"rumyantseva":  {},
+	"noisersup":    {},
+	"Fashander":    {},
+	"chilagrow":    {},
+	"b1ron":        {},
+}

--- a/detect-matching-pr/main.go
+++ b/detect-matching-pr/main.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v56/github"
 	"github.com/sethvargo/go-githubactions"
 
 	"github.com/FerretDB/github-actions/internal"
@@ -31,7 +31,7 @@ func main() {
 
 	ctx := context.Background()
 	action := githubactions.New()
-	client := internal.GitHubClient(ctx, action, "GITHUB_TOKEN")
+	client := internal.GitHubClient(action, "GITHUB_TOKEN")
 
 	internal.DebugEnv(action)
 

--- a/detect-matching-pr/main_test.go
+++ b/detect-matching-pr/main_test.go
@@ -39,7 +39,7 @@ func TestDetect(t *testing.T) {
 		})
 
 		action := githubactions.New(githubactions.WithGetenv(getEnv))
-		actual, err := detect(ctx, action, internal.GitHubClient(ctx, action, "GITHUB_TOKEN"))
+		actual, err := detect(ctx, action, internal.GitHubClient(action, "GITHUB_TOKEN"))
 		require.NoError(t, err)
 		expected := &result{
 			owner:  "AlekSi",
@@ -58,7 +58,7 @@ func TestDetect(t *testing.T) {
 		})
 
 		action := githubactions.New(githubactions.WithGetenv(getEnv))
-		actual, err := detect(ctx, action, internal.GitHubClient(ctx, action, "GITHUB_TOKEN"))
+		actual, err := detect(ctx, action, internal.GitHubClient(action, "GITHUB_TOKEN"))
 		require.NoError(t, err)
 		expected := &result{
 			owner:  "FerretDB",
@@ -77,7 +77,7 @@ func TestDetect(t *testing.T) {
 		})
 
 		action := githubactions.New(githubactions.WithGetenv(getEnv))
-		actual, err := detect(ctx, action, internal.GitHubClient(ctx, action, "GITHUB_TOKEN"))
+		actual, err := detect(ctx, action, internal.GitHubClient(action, "GITHUB_TOKEN"))
 		require.NoError(t, err)
 		expected := &result{
 			owner:  "AlekSi",
@@ -96,7 +96,7 @@ func TestDetect(t *testing.T) {
 		})
 
 		action := githubactions.New(githubactions.WithGetenv(getEnv))
-		actual, err := detect(ctx, action, internal.GitHubClient(ctx, action, "GITHUB_TOKEN"))
+		actual, err := detect(ctx, action, internal.GitHubClient(action, "GITHUB_TOKEN"))
 		require.NoError(t, err)
 		expected := &result{
 			owner:  "AlekSi",
@@ -115,7 +115,7 @@ func TestDetect(t *testing.T) {
 		})
 
 		action := githubactions.New(githubactions.WithGetenv(getEnv))
-		actual, err := detect(ctx, action, internal.GitHubClient(ctx, action, "GITHUB_TOKEN"))
+		actual, err := detect(ctx, action, internal.GitHubClient(action, "GITHUB_TOKEN"))
 		require.NoError(t, err)
 		expected := &result{
 			owner:  "FerretDB",
@@ -134,7 +134,7 @@ func TestDetect(t *testing.T) {
 		})
 
 		action := githubactions.New(githubactions.WithGetenv(getEnv))
-		actual, err := detect(ctx, action, internal.GitHubClient(ctx, action, "GITHUB_TOKEN"))
+		actual, err := detect(ctx, action, internal.GitHubClient(action, "GITHUB_TOKEN"))
 		require.NoError(t, err)
 		expected := &result{
 			owner:  "AlekSi",
@@ -153,7 +153,7 @@ func TestDetect(t *testing.T) {
 		})
 
 		action := githubactions.New(githubactions.WithGetenv(getEnv))
-		actual, err := detect(ctx, action, internal.GitHubClient(ctx, action, "GITHUB_TOKEN"))
+		actual, err := detect(ctx, action, internal.GitHubClient(action, "GITHUB_TOKEN"))
 		require.NoError(t, err)
 		expected := &result{
 			owner:  "AlekSi",
@@ -172,7 +172,7 @@ func TestDetect(t *testing.T) {
 		})
 
 		action := githubactions.New(githubactions.WithGetenv(getEnv))
-		actual, err := detect(ctx, action, internal.GitHubClient(ctx, action, "GITHUB_TOKEN"))
+		actual, err := detect(ctx, action, internal.GitHubClient(action, "GITHUB_TOKEN"))
 		require.NoError(t, err)
 		expected := &result{
 			owner:  "AlekSi",

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/FerretDB/github-actions
 go 1.21
 
 require (
-	github.com/google/go-github/v49 v49.1.0
+	github.com/FerretDB/gh v0.0.0-20231018105951-73ebe14be642
+	github.com/google/go-github/v56 v56.0.0
 	github.com/jdkato/prose/v2 v2.0.0
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/shurcooL/githubv4 v0.0.0-20230704064427-599ae7bbf278
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/crypto v0.14.0 // indirect; always use @latest
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/oauth2 v0.13.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/FerretDB/gh v0.0.0-20231018105951-73ebe14be642 h1:vxrZrSOktmI1v4U2aavNMMBL6SpUYluRCQX4xiSKMsQ=
+github.com/FerretDB/gh v0.0.0-20231018105951-73ebe14be642/go.mod h1:IZaVgs+IhUzLBYd2lfJjS5U2OnwuuvvLvypP1zHftSY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,8 +18,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github/v49 v49.1.0 h1:LFkMgawGQ8dfzWLH/rNE0b3u1D3n6/dw7ZmrN3b+YFY=
-github.com/google/go-github/v49 v49.1.0/go.mod h1:MUUzHPrhGniB6vUKa27y37likpipzG+BXXJbG04J334=
+github.com/google/go-github/v56 v56.0.0 h1:TysL7dMa/r7wsQi44BjqlwaHvwlFlqkK8CtBWCX3gb4=
+github.com/google/go-github/v56 v56.0.0/go.mod h1:D8cdcX98YWJvi7TLo7zM4/h8ZTx6u6fwGEkCdisopo0=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/jdkato/prose v1.1.1/go.mod h1:jkF0lkxaX5PFSlk9l4Gh9Y+T57TqUZziWT7uZbW5ADg=
@@ -49,8 +51,6 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
-golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/internal/github.go
+++ b/internal/github.go
@@ -15,19 +15,17 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
-	"time"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/FerretDB/gh"
+	"github.com/google/go-github/v56/github"
 	"github.com/sethvargo/go-githubactions"
-	"golang.org/x/oauth2"
 )
 
 // GitHubClient returns GitHub API client with token from the given environment variable.
-func GitHubClient(ctx context.Context, action *githubactions.Action, tokenVar string) *github.Client {
+func GitHubClient(action *githubactions.Action, tokenVar string) *github.Client {
 	// without the token, our anonymous requests hit the rate limit too often
 	token := action.Getenv(tokenVar)
 	if token == "" {
@@ -35,29 +33,10 @@ func GitHubClient(ctx context.Context, action *githubactions.Action, tokenVar st
 		return nil
 	}
 
-	httpClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: token},
-	))
-	httpClient.Transport = NewTransport(httpClient.Transport, action)
-
-	c := github.NewClient(httpClient)
-	c.UserAgent = "github-actions/1.0 (+https://github.com/FerretDB/github-actions)"
-
-	// Query rate limit to check that the client is able to make queries.
-	// See https://docs.github.com/en/rest/rate-limit.
-	// We can't use https://docs.github.com/en/rest/users/users#get-the-authenticated-user API,
-	// because short-lived automatic GITHUB_TOKEN is provided by GitHub Actions App that can't access this API
-	// (and doesn't have authenticated user).
-	rl, _, err := c.RateLimits(ctx)
+	c, err := gh.NewRESTClient(token, action.Debugf)
 	if err != nil {
-		action.Fatalf("Failed to query rate limit: %s.", err)
-		return nil
+		action.Fatalf("Failed to create GitHub client: %s.", err)
 	}
-
-	action.Infof(
-		"Rate limit: %d/%d, resets at: %s.",
-		rl.Core.Remaining, rl.Core.Limit, rl.Core.Reset.Format(time.RFC3339),
-	)
 
 	return c
 }

--- a/internal/graphql/pull_request.go
+++ b/internal/graphql/pull_request.go
@@ -31,8 +31,6 @@ type PullRequest struct {
 	Title     string
 	Body      string
 	Closed    bool
-	Author    string
-	AuthorBot bool
 	Labels    []string
 	AutoMerge bool
 
@@ -105,12 +103,6 @@ type pullRequest struct {
 
 	Closed githubv4.Boolean
 
-	// https://docs.github.com/en/graphql/reference/interfaces#actor
-	Author struct {
-		Typename githubv4.String `graphql:"__typename"`
-		Login    githubv4.String
-	}
-
 	// https://docs.github.com/en/graphql/reference/interfaces#labelable
 	Labels struct {
 		Nodes []struct {
@@ -174,11 +166,6 @@ func (c *Client) GetPullRequest(ctx context.Context, nodeID string) *PullRequest
 		Title:  string(q.Node.PullRequest.Title),
 		Body:   string(q.Node.PullRequest.Body),
 		Closed: bool(q.Node.PullRequest.Closed),
-		Author: string(q.Node.PullRequest.Author.Login),
-	}
-
-	if q.Node.PullRequest.Author.Typename == "Bot" {
-		res.AuthorBot = true
 	}
 
 	labelNodes := q.Node.PullRequest.Labels.Nodes

--- a/internal/graphql/pull_request_test.go
+++ b/internal/graphql/pull_request_test.go
@@ -37,12 +37,10 @@ func TestPullRequest(t *testing.T) {
 		t.Parallel()
 
 		expected := &PullRequest{
-			Title:     "Bump github.com/go-task/task/v3 from 3.14.0 to 3.14.1 in /tools",
-			Body:      "Bumps [github.com/go-task/task/v3](https://github.com/go-task/task) from 3.14.0 to 3.14.1.",
-			Closed:    true,
-			Author:    "dependabot",
-			AuthorBot: true,
-			Labels:    []string{"deps"},
+			Title:  "Bump github.com/go-task/task/v3 from 3.14.0 to 3.14.1 in /tools",
+			Body:   "Bumps [github.com/go-task/task/v3](https://github.com/go-task/task) from 3.14.0 to 3.14.1.",
+			Closed: true,
+			Labels: []string{"deps"},
 		}
 		actual := c.GetPullRequest(ctx, "PR_kwDOGfwnTc48nVkp")
 		actual.Body, _, _ = strings.Cut(actual.Body, "\n")
@@ -57,7 +55,6 @@ func TestPullRequest(t *testing.T) {
 			Title:  "Migrate to `ProjectV2`",
 			Body:   "Test body.",
 			Closed: true,
-			Author: "AlekSi",
 			Labels: []string{"code/chore", "trust"},
 			ProjectFields: map[string]Fields{
 				"Test project": {
@@ -81,7 +78,6 @@ func TestPullRequest(t *testing.T) {
 		expected := &PullRequest{
 			Title:     "Please do not merge this PR.",
 			Body:      "It is for testing.",
-			Author:    "AlekSi",
 			Labels:    []string{"not ready", "do not merge"},
 			AutoMerge: true,
 		}

--- a/restart-pr-actions/main.go
+++ b/restart-pr-actions/main.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/go-github/v49/github"
+	"github.com/google/go-github/v56/github"
 	"github.com/sethvargo/go-githubactions"
 
 	"github.com/FerretDB/github-actions/internal"
@@ -32,7 +32,7 @@ func main() {
 
 	ctx := context.Background()
 	action := githubactions.New()
-	client := internal.GitHubClient(ctx, action, "GITHUB_TOKEN")
+	client := internal.GitHubClient(action, "GITHUB_TOKEN")
 
 	internal.DebugEnv(action)
 

--- a/restart-pr-actions/main.go
+++ b/restart-pr-actions/main.go
@@ -179,7 +179,7 @@ func getPR(ctx context.Context, action *githubactions.Action, client *github.Cli
 
 // getBranch returns branch's head SHA.
 func getBranch(ctx context.Context, action *githubactions.Action, client *github.Client, owner, repo, branch string) (string, error) {
-	br, _, err := client.Repositories.GetBranch(ctx, owner, repo, branch, false)
+	br, _, err := client.Repositories.GetBranch(ctx, owner, repo, branch, 5)
 	if err != nil {
 		return "", fmt.Errorf("getBranch: %w", err)
 	}


### PR DESCRIPTION
There is no need to get the same mostly static list all the time.