### PR TITLE
Add PR title length check

### DIFF
--- a/conform-pr/main.go
+++ b/conform-pr/main.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"strings"
 	"text/tabwriter"
+	"unicode/utf8"
 
 	"github.com/google/go-github/v56/github"
 	"github.com/jdkato/prose/v2"
@@ -287,6 +288,10 @@ func checkTitle(_ *githubactions.Action, title string) error {
 	// https://github.com/jdkato/prose/tree/v2#tagging
 	if tok.Tag != "VBP" {
 		return fmt.Errorf("PR title must start with an imperative verb (got %q).", tok.Tag)
+	}
+
+	if utf8.RuneCountInString(title) > 72 {
+		return fmt.Errorf("PR title must not longer than 72 unicode runes")
 	}
 
 	return nil

--- a/conform-pr/main_test.go
+++ b/conform-pr/main_test.go
@@ -187,6 +187,14 @@ func TestCheckTitle(t *testing.T) {
 		name:        "pull_request/title_with_invalid_imperative_verb",
 		title:       "A title without an imperative verb at the beginning",
 		expectedErr: nil, // `prose` fails to detect this as a verb
+	}, {
+		name:        "pull_request/title_with_72_unicode_runes",
+		title:       fmt.Sprintf("A%sB", string(make([]rune, 70))),
+		expectedErr: nil,
+	}, {
+		name:        "pull_request/title_with_more_than_72_unicode_runes",
+		title:       fmt.Sprintf("A%sB", string(make([]rune, 71))),
+		expectedErr: fmt.Errorf("PR title must not longer than 72 unicode runes"),
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Resolves: https://github.com/FerretDB/github-actions/issues/230

PS. I'm getting this error when running `go test ./conform-pr/...`

```
go test ./conform-pr/...
::debug::checkBody:%0A
::debug::checkBody:%0A00000000  0a                                                |.|%0A
::debug::checkBody:%0A00000000  49 27 6d 20 61 20 62 6f  64 79 20 77 69 74 68 20  |I'm a body with |%0A00000010  61 20 64 6f 74 2e                                 |a dot.|%0A
::debug::checkBody:%0A00000000  49 27 6d 20 61 20 62 6f  64 79 20 77 69 74 68 20  |I'm a body with |%0A00000010  61 20 70 75 6e 63 74 75  61 74 69 6f 6e 20 6d 61  |a punctuation ma|%0A00000020  72 6b 21 0d 0a                                    |rk!..|%0A
::debug::checkBody:%0A00000000  41 6d 20 49 20 61 20 62  6f 64 79 20 77 69 74 68  |Am I a body with|%0A00000010  20 61 20 70 75 6e 63 74  75 61 74 69 6f 6e 20 6d  | a punctuation m|%0A00000020  61 72 6b 3f                                       |ark?|%0A
::debug::checkBody:%0A00000000  49 27 6d 20 61 20 62 6f  64 79 20 77 69 74 68 6f  |I'm a body witho|%0A00000010  75 74 20 61 20 64 6f 74  0a                       |ut a dot.|%0A
::debug::checkBody:%0A00000000  21 0d 0a                                          |!..|%0A
::error::CONFORM_TOKEN is not set.
FAIL    github.com/FerretDB/github-actions/conform-pr   3.463s
FAIL
```

@AlekSi do you have any clue for solving this? Thx

PSS. Due to the error above, I only run `go test ./conform-pr/... -run=TestCheckTitle` in my local.