### PR TITLE
Use Ubicloud Transparent Cache instead of a separate step

### DIFF
--- a/setup-go/action.yml
+++ b/setup-go/action.yml
@@ -25,27 +25,10 @@ runs:
       working-directory: ${{ github.action_path }}
       shell: bash
 
-    # There is no _documented_ way to detect Ubicloud; UBICLOUD_CACHE_URL works in practice for now.
-    #
-    # The output variable is required because env context does not contain variables inherited by the runner process,
-    # so just env.UBICLOUD_CACHE_URL would not work.
-    - name: Check for Ubicloud
-      id: ubicloud
-      run: echo YES=$UBICLOUD_CACHE_URL >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Restore GitHub cache
-      if: inputs.cache-key != '' && steps.ubicloud.outputs.YES == ''
+    # Restores from Ubicloud cache if enabled in the UI
+    # https://www.ubicloud.com/docs/github-actions-integration/ubicloud-cache#ubicloud-transparent-cache
+    - name: Restore cache
       uses: actions/cache@v4
-      with:
-        path: ${{ steps.run.outputs.cache_path }}
-        key: ${{ inputs.cache-key }}-${{ steps.run.outputs.cache_week }}-${{ hashFiles('**/go.mod') }}
-        restore-keys: |
-          ${{ inputs.cache-key }}-${{ steps.run.outputs.cache_week }}-
-
-    - name: Restore Ubicloud cache
-      if: inputs.cache-key != '' && steps.ubicloud.outputs.YES != ''
-      uses: ubicloud/cache@v4
       with:
         path: ${{ steps.run.outputs.cache_path }}
         key: ${{ inputs.cache-key }}-${{ steps.run.outputs.cache_week }}-${{ hashFiles('**/go.mod') }}


### PR DESCRIPTION
We recently introduced [Ubicloud Transparent Cache](https://www.ubicloud.com/blog/github-actions-transparent-cache).

You no longer need to use the forked version `ubicloud/cache`. If you enable this feature from the Ubicloud Console for your installation, `actions/cache` will automatically use Ubicloud Cache.